### PR TITLE
Add Linux compatibility

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,4 +7,5 @@
     * BREAKING CHANGE: --image-count replaces --download-only, when set it
       downloads that number of images per desktop into the download directory
     * BREAKING CHANGE: Removed --min-resolution option, filtering now uses an
-      algorithm that takes into account aspect ratio and resolution
+	  algorithm that takes into account aspect ratio and resolution
+    * FEATURE: Added support for Linux systems

--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 reddit-background
 =================
 
-Set your Mac OS X desktop background to images pulled from [Reddit](https://reddit.com)
+Set your Mac OS X or Linux desktop background to images pulled from [Reddit](https://reddit.com)
 
 ![Screenshot](https://raw.githubusercontent.com/rconradharris/reddit-background/master/screenshot.jpg)
 
 Features
 --------
 
-- Supports multiple monitors
+- Supports multiple monitors (Mac OS X only)
 - Handles multiple subreddits
 - Aspect ratio and resolution filtering ensures your backgrounds are always beautiful
 - Flexible sorting lets you choose the quality of images it downloads

--- a/reddit-background
+++ b/reddit-background
@@ -10,7 +10,7 @@ SYNOPSIS
 
 DESCRIPTION
 
-    Set Mac OS X desktop backgrounds to images pulled from Reddit.
+    Set Mac OS X and Linux desktop backgrounds to images pulled from Reddit.
 
 EXAMPLES
 

--- a/reddit-background
+++ b/reddit-background
@@ -383,7 +383,6 @@ def _get_desktops_with_defaults():
 
     desktops = []
     for num, res in enumerate(matches, start=1):
-        print num
         width = int(res[0])
         height = int(res[1])
         desktop = Desktop(num, width, height,

--- a/reddit-background
+++ b/reddit-background
@@ -52,6 +52,10 @@ RE_RESOLUTION_DISPLAYS = re.compile("Resolution: (\d+)\sx\s(\d+)")
 _VERBOSITY = 0
 _DOWNLOAD_DIRECTORY = None
 _IMAGE_COUNT = 0
+_LINUX = False
+if _LINUX:
+    from Xlib import X, display
+    from Xlib.ext import randr
 
 # Consts
 WEIGHT_ASPECT_RATIO = 1.0
@@ -328,11 +332,19 @@ class Desktop(object):
 
     def set_background(self, filename):
         log('Setting background for desktop {0}'.format(self.num))
-        script = 'tell application "System Events" to set picture of item'\
-                 ' {num} of (a reference to every desktop) to "{filename}"'\
-                 .format(num=self.num, filename=filename)
-        if subprocess.call(['/usr/bin/osascript', '-e', script]):
-            warn("unable to set background to '{}'".format(filename))
+
+        # set wallpaper on Linux
+        if _LINUX:
+            if subprocess.call(['feh', '--bg-fill', filename]):
+                warn("unable to set background to '{}'".format(filename))
+
+        # set wallpaper on Mac
+        else:
+            script = 'tell application "System Events" to set picture of item'\
+                    ' {num} of (a reference to every desktop) to "{filename}"'\
+                    .format(num=self.num, filename=filename)
+            if subprocess.call(['/usr/bin/osascript', '-e', script]):
+                warn("unable to set background to '{}'".format(filename))
 
 
 def _get_desktops_with_defaults():
@@ -341,12 +353,37 @@ def _get_desktops_with_defaults():
     Customizations will be performed by overriding these values, first using
     the config file and later command-line options.
     """
-    p = subprocess.Popen(["/usr/sbin/system_profiler", "SPDisplaysDataType"],
+
+    # get Linux displays
+    # source: http://stackoverflow.com/questions/8705814/get-display-count-and-resolution-for-each-display-in-python-without-xrandr
+    if _LINUX:
+        d = display.Display()
+        s = d.screen()
+        window = s.root.create_window(0, 0, 1, 1, 1, s.root_depth)
+        res = randr.get_screen_resources(window)
+        modes = []
+        desktops = []
+        matches = []
+        for output in res.outputs:
+            # use largest resolution per output
+            available_modes = randr.get_output_info(window, output, 0).modes
+            if len(available_modes) > 0:
+                modes.append(available_modes[0])
+
+        for mode in res.modes:
+            if mode.id in modes:
+                matches.append((mode.width, mode.height))
+
+    # get Mac displays
+    else:
+        p = subprocess.Popen(["/usr/sbin/system_profiler", "SPDisplaysDataType"],
                          stdout=subprocess.PIPE)
-    (output, err) = p.communicate()
-    matches = re.findall(RE_RESOLUTION_DISPLAYS, output)
+        (output, err) = p.communicate()
+        matches = re.findall(RE_RESOLUTION_DISPLAYS, output)
+
     desktops = []
     for num, res in enumerate(matches, start=1):
+        print num
         width = int(res[0])
         height = int(res[1])
         desktop = Desktop(num, width, height,

--- a/reddit-background
+++ b/reddit-background
@@ -36,6 +36,11 @@ import sys
 import urllib2
 import urlparse
 import uuid
+from sys import platform
+# Identify displays on Linux platforms using Xlib
+if platform == "linux" or platform == "linux2":
+    import Xlib.display
+    import Xlib.ext.randr
 
 __version__ = '2.0beta'
 
@@ -52,10 +57,6 @@ RE_RESOLUTION_DISPLAYS = re.compile("Resolution: (\d+)\sx\s(\d+)")
 _VERBOSITY = 0
 _DOWNLOAD_DIRECTORY = None
 _IMAGE_COUNT = 0
-_LINUX = False
-if _LINUX:
-    from Xlib import X, display
-    from Xlib.ext import randr
 
 # Consts
 WEIGHT_ASPECT_RATIO = 1.0
@@ -334,7 +335,7 @@ class Desktop(object):
         log('Setting background for desktop {0}'.format(self.num))
 
         # set wallpaper on Linux
-        if _LINUX:
+        if platform == "linux" or platform == "linux2":
             if subprocess.call(['feh', '--bg-fill', filename]):
                 warn("unable to set background to '{}'".format(filename))
 
@@ -356,17 +357,16 @@ def _get_desktops_with_defaults():
 
     # get Linux displays
     # source: http://stackoverflow.com/questions/8705814/get-display-count-and-resolution-for-each-display-in-python-without-xrandr
-    if _LINUX:
-        d = display.Display()
+    if platform == "linux" or platform == "linux2":
+        d = Xlib.display.Display()
         s = d.screen()
         window = s.root.create_window(0, 0, 1, 1, 1, s.root_depth)
-        res = randr.get_screen_resources(window)
+        res = Xlib.ext.randr.get_screen_resources(window)
         modes = []
-        desktops = []
         matches = []
         for output in res.outputs:
             # use largest resolution per output
-            available_modes = randr.get_output_info(window, output, 0).modes
+            available_modes = Xlib.ext.randr.get_output_info(window, output, 0).modes
             if len(available_modes) > 0:
                 modes.append(available_modes[0])
 
@@ -632,6 +632,9 @@ def _handle_cli_options(desktops):
 
     if args.desktop:
         desktops = [d for d in desktops if d.num == args.desktop]
+        if platform == "linux" or platform == "linux2":
+            warn('--desktop is ignored on Linux systems')
+
 
     for desktop in desktops:
         if args.url:


### PR DESCRIPTION
I added some Linux support and a `_LINUX` global to control it.

# Dependencies
- `feh` - default to nearly every distro
- `python-xlib` - used to get display resolution information
# Limitations
- `--desktop` option doesn't do anything because `feh` [doesn't support setting wallpaper per display](https://faq.i3wm.org/question/6247/assigning-individual-wallpaper-to-monitors.1.html) wihout modifying xorg.conf