### PR TITLE
Imprint title on images

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -18,3 +18,11 @@
     * FEATURE: Added support for Linux systems
     * BUGFIX: Fix issue where long titles caused filenames to be too long for
       system to handle
+
+2.1beta (changes by doconix@gmail.com, tested on OS X Sierra)
+    * FEATURE: Added image fitting to desktop resolution. PIL (pillow) is used 
+      for image manipulation but fails nicely when not installed on the machine.
+    * FEATURE: Added title imprinting.  This included new options, config parsing, 
+      another example config, new sections in the README, etc.  
+      
+     

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ background. You then set `System Preferences -> Desktop -> Backgrounds` to
 point to the download directory for each desktop.
 
 
-### Scale to Desktop Size
+### Image Scaling
 
 By default, images are downloaded in their original resolution.  When the "fit" option is set, reddit-background fits the image to your screen
 resolution by adding black bars where needed.  
@@ -165,8 +165,9 @@ This option can be set as a default for all desktops or can be set individually 
 configuration enables fitting for all downloaded images:
 
     [default]
-    fit_images = True
+    image_scaling=fit
     
+Currently, `fit` is the only scaling option available.
     
 ### Show Title of Image
 
@@ -186,7 +187,7 @@ image.
 
 Third, you can imprint the title directly on the image itself.  This option
 requires that you load additional modules into Python.  This option works
-best when paired with `fit_images=True`.
+best when paired with `image_scaling=fit`.
 
 #### Prerequisites for Imprinting Titles
 
@@ -238,7 +239,7 @@ Example 1: the following configuration places the title at the bottom-left corne
 uses the defaults for font and size:
 
     [default]
-    fit_images=True
+    image_scaling=fit
     imprint_position=bottom left
 
 Example 2: the following configuration centers the title 200 pixels from the top of the image.  It won't
@@ -246,7 +247,7 @@ wrap lines because the box width is set so large.  The zero transparency makes t
 invisible. A custom font, size, and color are set.
 
     [default]
-    fit_images=True
+    image_scaling=fit
     imprint_position=top center
     imprint_size=2000:200:10:0
     imprint_font=Perpetual Bold:20:#3CB371
@@ -256,7 +257,7 @@ is relative to the image itself and not to your desktop.
 In other words, a placement of "top left" means the top-left corner of the **image**.  
 If your desktop cuts off the top of your image (in order to cover the entire desktop), 
 the title box will not be visible.  The solution is to always 
-set `fit_images=True` to ensure images are fit to your desktop size before imprinting is
+set `image_scaling=fit` to ensure images are fit to your desktop size before imprinting is
 done.
 
 Note that font filenames are not always the same as the displayed name in OS dialog boxes.

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Features
 - Handles multiple subreddits
 - Aspect ratio and resolution filtering ensures your backgrounds are always beautiful
 - Flexible sorting lets you choose the quality of images it downloads
+- Optionally imprints the title on each image
 - Can pick images that match the current season
 - Download only option (`--image-count`) if you want to use OS X's existing
   folder-based background selector
@@ -115,6 +116,7 @@ Currently the only one included is `{seasonal}` which will choose from amongst
 [/r/AutumnPorn](https://reddit.com/r/AutumnPorn) based on the current season
 (in the northern hemisphere).
 
+
 ### Command-Line Usage
 
 In addition to specifying a configuration file, you can also customize
@@ -148,22 +150,130 @@ images into the download directory but not actually set them as the
 background. You then set `System Preferences -> Desktop -> Backgrounds` to
 point to the download directory for each desktop.
 
-### Show title of image
+
+### Scale to Desktop Size
+
+By default, images are downloaded in their original resolution.  When the "fit" option is set, reddit-background fits the image to your screen
+resolution by adding black bars where needed.  
+
+While your OS likely has this option already, using this configuration option makes sense when
+paired with the "Imprint Title" option.  By scaling the image first and then imprinting the title, 
+you get a consistent font size as well as a guarantee the imprint will be on the screen (and not 
+scaled off one side or the other).
+
+This option can be set as a default for all desktops or can be set individually per desktop.  The following
+configuration enables fitting for all downloaded images:
+
+    [default]
+    fit_images = True
+    
+    
+### Show Title of Image
 
 If you'd like to know the title of the background you're looking at, you have
-two different options.
+three different options.
 
-On the command-line you can run:
+First, on the command-line you can run:
 
     reddit-background --what
     Desktop 1
         Perth, Western Australia, from Elizabeth Quay [5376x3024].jpg
 
-Another option is to enable the `desktop_symlinks=True` configuration. This
+Second, you can enable the `desktop_symlinks=True` configuration. This
 will place a symlink on you desktop to your current images. This gives you
 easy access to the image, but more importantly, shows you the title of the
 image.
 
+Third, you can imprint the title directly on the image itself.  This option
+requires that you load additional modules into Python.  This option works
+best when paired with `fit_images=True`.
+
+Prerequisites for Imprinting Titles
+-----------------------------------
+
+Imprinting requires the Python Imaging Library.  We suggest installing the 
+[Pillow](https://python-pillow.org/) fork of this library.  The directions below
+are a quick guide.  Full documentation is available on the pillow site.
+
+Windows users can download an installable binary from the pillow site.
+
+Mac and Linux users should ensure they have `freetype` and `libjpeg` installed
+**before** installing `pillow`.  Linux likely has these already, and Mac
+users can add them with:
+
+    brew install freetype libjpeg
+    
+Once you have these dependencies are available on your system, install
+pillow with one of the following commands:
+
+    pip install Pillow
+    # or
+    easy_install Pillow
+
+Imprinting Configuration
+------------------------
+
+Configuration can be done globally in the `[default]` section or per desktop.
+If you specify desktop sections, the default section is entirely ignored.
+The options are as follows:
+
+    imprint_position=<horizontal> <vertical>
+    imprint_size=[box width]:[margin]:[padding]:[transparency]
+    imprint_font=[font filename]:[font size]:[font color]
+
+The first option, `imprint_position`, is required and is what activates 
+imprinting.  The others are optional.
+
+| Argument      | Possible Values                                          | Default |
+|---------------|----------------------------------------------------------|---------|
+| horizontal    | top, center, bottom                                      | center  |
+| vertical      | left, center, right                                      | center  |
+| box width     | number of pixels before line wrap                        | 500     |
+| margin        | number of pixels from the edge of image                  | 50      |
+| padding       | number of pixels inside of text box                      | 8       |
+| transparency  | number from 0 to 100 for percent transparency (text box) | 40      |
+| font filename | filename of TrueType font on your system to use          | Arial   |
+| font size     | font size                                                | 50      |
+| font color    | hex code: #112233, or RGB triple: (255, 128, 75)         | #E8BC61 |
+
+Example 1: the following configuration places the title at the bottom-left corner of the image. It
+uses the defaults for font and size:
+
+    fit_images=True
+    imprint_position=bottom left
+
+Example 2: the following ocnfiguration centers the title 200 pixels from the top of the image.  It won't
+wrap lines because the box width is set so large.  The zero transparency makes the box background
+invisible. A custom font, size, and color are set.
+
+    imprint_position=top center
+    imprint_size=2000:200:10:0
+    imprint_font=Perpetual Bold:20:#3CB371
+
+Since the program cannot know how your OS will scale the image, placement 
+is relative to the image itself and not to your desktop.
+In other words, a placement of "top left" means the top-left corner of the **image**.  
+If your desktop cuts off the top of your image (in order to cover the entire desktop), 
+the title box will not be visible.  The solution is to always 
+set `fit_images=True` to ensure images are fit to your desktop size before imprinting is
+done.
+
+Note that font filenames are not always the same as the displayed name in OS dialog boxes.
+For example, the filename for "American Typewriter" on my machine is "AmericanTypewriter.ttf"
+(without a space).  The extension can be omitted, and only TrueType fonts are supported.
+
+Transparency affects the text box background only (not the title text). This semi-transparent
+box is added behind the title because no color is appropriate across all images.  If you 
+use a white font, some images will have white pixels in the title area.  If you instead use
+a black font, other images will have black pixels in the same area.  The box allows 
+your desired color to be read regardless of the image colors beneath the title.
+
+Imprinting with Command-Line Options
+------------------------------------
+
+Options can be specified on the command line, as in the following example:
+
+    reddit-background --imprint-position="top right" --imprint-size=1000:500:100:70 --imprint-font="Arial:50:#888888"
 
 ### Image Choosing Algorithms
 

--- a/README.md
+++ b/README.md
@@ -188,8 +188,7 @@ Third, you can imprint the title directly on the image itself.  This option
 requires that you load additional modules into Python.  This option works
 best when paired with `fit_images=True`.
 
-Prerequisites for Imprinting Titles
------------------------------------
+#### Prerequisites for Imprinting Titles
 
 Imprinting requires the Python Imaging Library.  We suggest installing the 
 [Pillow](https://python-pillow.org/) fork of this library.  The directions below
@@ -210,8 +209,7 @@ pillow with one of the following commands:
     # or
     easy_install Pillow
 
-Imprinting Configuration
-------------------------
+#### Imprinting Configuration
 
 Configuration can be done globally in the `[default]` section or per desktop.
 If you specify desktop sections, the default section is entirely ignored.
@@ -268,8 +266,7 @@ use a white font, some images will have white pixels in the title area.  If you 
 a black font, other images will have black pixels in the same area.  The box allows 
 your desired color to be read regardless of the image colors beneath the title.
 
-Imprinting with Command-Line Options
-------------------------------------
+#### Imprinting with Command-Line Options
 
 Options can be specified on the command line, as in the following example:
 

--- a/README.md
+++ b/README.md
@@ -237,13 +237,16 @@ imprinting.  The others are optional.
 Example 1: the following configuration places the title at the bottom-left corner of the image. It
 uses the defaults for font and size:
 
+    [default]
     fit_images=True
     imprint_position=bottom left
 
-Example 2: the following ocnfiguration centers the title 200 pixels from the top of the image.  It won't
+Example 2: the following configuration centers the title 200 pixels from the top of the image.  It won't
 wrap lines because the box width is set so large.  The zero transparency makes the box background
 invisible. A custom font, size, and color are set.
 
+    [default]
+    fit_images=True
     imprint_position=top center
     imprint_size=2000:200:10:0
     imprint_font=Perpetual Bold:20:#3CB371

--- a/examples/title_imprint.conf
+++ b/examples/title_imprint.conf
@@ -1,0 +1,38 @@
+# To use this, copy it to ~/.reddit-background.conf and modify it to your
+# liking.
+#
+# This config downloads 50 images to /home/me/RedditBackgrounds/.
+# It first fits the images to the size of each desktop in preparation
+# for title imprinting, with black bars along the edges where needed.
+#
+# Since it downloads images only, it assumes you want to use the OS
+# native folder-based background selector.  The OS preferences are set
+# to center the images (since each will be the exact size of the desktop
+# already).
+#
+# On the first desktop, the title is imprinted on the bottom-left corner
+# of each image, with a 50 pixel margin, 10 pixel padding, and 40 percent
+# transparency.  The font file is JennaSue.ttf (PIL will look for this file in the
+# regular OS font directory), font size is 90 pixels, and color is gold.
+#
+# On the second desktop, the title is imprinted on the top center of the 
+# image, with a 10 pixel margin, no padding, and opaque background box.
+# The font file is helvetica.ttf (PIL will look for this file in the
+# regular OS font directory), font size is 20 pixels, and color is red.
+
+[default]
+image_count = 50
+download_directory = /home/me/RedditBackgrounds/
+fit_images = True
+
+[desktop1]
+subreddits=WaterPorn:hot:50:month
+imprint_position=bottom left
+imprint_size=500:50:10:40
+imprint_font=JennaSue:90:#B4B232
+
+[desktop2]
+subreddits=EarthPorn:hot:50:month
+imprint_position=top center
+imprint_size=500:10:0:100
+imprint_font=helvetica:20:#FF0000

--- a/examples/title_imprint.conf
+++ b/examples/title_imprint.conf
@@ -23,7 +23,7 @@
 [default]
 image_count = 50
 download_directory = /home/me/RedditBackgrounds/
-fit_images = True
+image_scale=fit
 
 [desktop1]
 subreddits=WaterPorn:hot:50:month

--- a/reddit-background
+++ b/reddit-background
@@ -36,7 +36,14 @@ import sys
 import urllib2
 import urlparse
 
-__version__ = '2.0beta'
+# since PIL is not in the standard library, using a try so it isn't necessary for the script
+try:
+    from PIL import Image as pilImage, ImageColor as pilImageColor, ImageDraw as pilImageDraw, ImageFont as pilImageFont
+    pil_available = True
+except ImportError:
+    pil_available = False
+
+__version__ = '2.1beta'
 
 # Defaults
 DEFAULT_SUBREDDIT_TOKENS = ['{seasonal}']
@@ -44,9 +51,13 @@ DEFAULT_CONFIG_PATH = u"~/.reddit-background.conf"
 DEFAULT_DOWNLOAD_DIRECTORY = u"~/Reddit Backgrounds"
 DEFAULT_USER_AGENT = "Mozilla/5.0 (X11; U; Linux i686) Gecko/20071127 Firefox/2.0.0.11"
 DEFAULT_IMAGE_CHOOSER = 'bestmatch'
+DEFAULT_IMPRINT_POSITION_TOKENS = []
+DEFAULT_IMPRINT_SIZE_TOKENS = [500, 50, 8, 40]
+DEFAULT_IMPRINT_FONT_TOKENS = ['Arial', 50, '#E8BC61']
 
 # Regexs
 RE_RESOLUTION_DISPLAYS = re.compile("Resolution: (\d+)\sx\s(\d+)")
+RE_TITLE_TAGS = re.compile('\[[^]]*]', flags=re.DOTALL)
 
 # Globals
 _VERBOSITY = 0
@@ -56,13 +67,13 @@ _DOWNLOAD_DIRECTORY = None
 _IMAGE_COUNT = 0
 _OS_HANDLER = None  # Set below...
 _IMAGE_CHOOSER = None
+_FIT_IMAGES = False
 
 # Consts
 WEIGHT_ASPECT_RATIO = 1.0
 WEIGHT_RESOLUTION = 1.0
 WEIGHT_JITTER = 0.25
 WEIGHT_REDDIT_SCORE = 1.0
-
 
 def set_verbosity(verbosity):
     global _VERBOSITY
@@ -118,6 +129,15 @@ def set_image_chooser(image_chooser):
 
 def get_image_chooser():
     return _IMAGE_CHOOSER or DEFAULT_IMAGE_CHOOSER
+
+
+def set_fit_images(fit_images):
+    global _FIT_IMAGES
+    _FIT_IMAGES = fit_images
+
+
+def get_fit_images():
+    return _FIT_IMAGES
 
 
 def _safe_makedirs(name, mode=0777):
@@ -388,12 +408,67 @@ _IMAGE_CHOOSER_CLASSES = {
 }
 
 
+class ImprintConf(object):
+    def __init__(self):
+        self.set_position_tokens(None)
+        self.set_size_tokens(None)
+        self.set_font_tokens(None)
+
+    def _parse_token(self, tokens, default_tokens, pos, conv, errormsg):
+        if tokens is None or len(tokens) <= pos:
+            tokens = default_tokens
+        val = tokens[pos]
+        if conv is not None:
+            try:
+                val = conv(val)
+            except:
+                self.warn(errormsg % val)
+                return default_tokens[pos]
+        return val
+
+    def set_position_tokens(self, tokens):
+        tokens = tokens or []
+        self.position_tokens = []
+        for token in tokens:
+            self.position_tokens.extend(token.split() if token else [])
+        
+    def set_size_tokens(self, tokens):
+        self.box_width = self._parse_token(tokens, DEFAULT_IMPRINT_SIZE_TOKENS,
+            0, int, 'Invalid box width specified for title imprint: %s')
+        self.margin = self._parse_token(tokens, DEFAULT_IMPRINT_SIZE_TOKENS,
+            1, int, 'Invalid box margin specified for title imprint: %s')
+        self.padding = self._parse_token(tokens, DEFAULT_IMPRINT_SIZE_TOKENS,
+            2, int, 'Invalid box padding specified for title imprint: %s')
+        self.transparency = self._parse_token(tokens, DEFAULT_IMPRINT_SIZE_TOKENS,
+            3, int, 'Invalid box transparency specified for title imprint: %s')
+        self.transparency = max(0, min(100, self.transparency))
+        
+    def set_font_tokens(self, tokens):
+        self.font_filename = self._parse_token(tokens, DEFAULT_IMPRINT_FONT_TOKENS,
+            0, None, None)
+        self.font_size = self._parse_token(tokens, DEFAULT_IMPRINT_FONT_TOKENS,
+            1, int, 'Invalid font specified for title imprint: %s')
+        self.font_color = self._parse_token(tokens, DEFAULT_IMPRINT_FONT_TOKENS,
+            2, None, None)
+            
+    def __str__(self):
+        '''For debugging'''
+        ret = []
+        for name in ('position_tokens', 'box_width', 'margin',
+            'padding', 'transparency', 'font_filename', 'font_size',
+            'font_color'):
+            ret.append('%s:%s' % (name, getattr(self, name)))
+        return '\n'.join(ret)
+
+
 class Desktop(object):
     def __init__(self, num, width, height, subreddit_tokens=None):
         self.num = num
         self.width = width
         self.height = height
         self.subreddit_tokens = subreddit_tokens or []
+        self.imprint_conf = ImprintConf()
+        
         # NOTE: we need to get the download-images at instantiation time and
         # cache the results b/c we'll later clear the download directory
         # before downloading the new images, meaning we can no longer tell
@@ -404,7 +479,7 @@ class Desktop(object):
     def subreddits(self):
         return [Subreddit.create_from_token(self, t)
                 for t in self.subreddit_tokens]
-
+                
     @property
     def download_directory(self):
         """Images are stored in ~/Reddit Backgrounds/Desktop 1"""
@@ -450,6 +525,10 @@ class Desktop(object):
                 continue  # Try next image...
             else:
                 paths.append(path)
+                if get_fit_images():
+                    image.fit_to_desktop(self)
+                if self.imprint_conf.position_tokens:
+                    image.imprint_title(self)
 
         return paths
 
@@ -553,6 +632,7 @@ class Image(object):
         self.resolution_score = resolution_score
         self.jitter_score = jitter_score
         self.reddit_score = reddit_score
+        self.img = None  # cached image data so we don't load/save/reload/resave jpegs
 
     @property
     def display_title(self):
@@ -560,6 +640,10 @@ class Image(object):
             return self.title
         else:
             return self.title[:self.TITLE_MAX_LENGTH - 3] + u'...'
+            
+    @property
+    def full_title(self):
+        return RE_TITLE_TAGS.sub('', self.title)
 
     @property
     def filename(self):
@@ -574,7 +658,104 @@ class Image(object):
         except IndexError:
             pass
         return filename
+        
+    def fit_to_desktop(self, desktop):
+        if not pil_available:
+            raise ImportError(u"Cannot fit image to desktop size because the python"
+                    u" imaging library is not available.  Please install `pillow` or"
+                    u" remove the fit option from your config.")
+        if self.img is None:
+            self.img = pilImage.open(os.path.join(desktop.download_directory, self.filename))
+        image_ratio = float(self.img.width) / float(self.img.height)
+        desktop_ratio = float(desktop.width) / float(desktop.height)
+        if image_ratio < desktop_ratio:
+            self.img = self.img.resize((int(desktop.height * image_ratio), desktop.height))
+        else:
+            self.img = self.img.resize((desktop.width, int(desktop.width / image_ratio)))
+        canvas = pilImage.new('RGB', (desktop.width, desktop.height), (0, 0, 0))
+        canvas.paste(self.img, (max(0, int((desktop.width - self.img.width) / 2.0)), 
+            max(0, int((desktop.height - self.img.height) / 2.0))))
+        self.img = canvas
+        self.img.save(os.path.join(desktop.download_directory, self.filename), 
+            "JPEG", quality=85)
+        self.width = self.img.width
+        self.height = self.img.height
 
+    def imprint_title(self, desktop):
+        if not pil_available:
+            raise ImportError(u"Cannot imprint title on image because the python imaging"
+                    u" library is not available.  Please install `pillow` or remove the"
+                    u" fit option from your config.")
+        if not self.full_title:
+            return
+        if self.img is None:
+            self.img = pilImage.open(os.path.join(desktop.download_directory, 
+                self.filename))
+        conf = desktop.imprint_conf
+        try:
+            font = pilImageFont.truetype(conf.font_filename, conf.font_size)
+        except IOError:
+            warn(u"Cannot open font file `%s`.  This must be specified as the font"
+                 u" filename, not the font name fromn system dialogs (although the two are"
+                 u" often the same). Trying `Arial.ttf` instead." % conf.font_filename)
+            font = pilImageFont.truetype('Arial', conf.font_size)
+        self.img = pilImage.open(os.path.join(desktop.download_directory, self.filename))
+        draw = pilImageDraw.ImageDraw(self.img)
+        lineheight = draw.textsize(self.title, font=font)[1]
+        maxwidth = conf.box_width
+        color = pilImageColor.getrgb(conf.font_color)
+        # split the title into lines that are less than maxwidth
+        lines = []
+        for title in self.full_title.splitlines():
+            start = 0
+            curparts = []
+            for part in ( t for t in title.split() if t ):
+                curparts.append(part)
+                if draw.textsize(u' '.join(curparts), font=font)[0] > maxwidth:
+                    if len(curparts) == 1:
+                        lines.append(u' '.join(curparts))
+                        curparts = []
+                    else:  
+                        lines.append(u' '.join(curparts[:-1]))
+                        curparts = [ curparts[-1] ]
+            if len(curparts) > 0:
+                lines.append(u' '.join(curparts))
+        # calculate the x and y
+        for line in lines:
+            maxwidth = max(maxwidth, draw.textsize(line, font=font)[0])
+        maxheight = len(lines) * lineheight 
+        if 'left' in conf.position_tokens:
+            x = conf.margin
+        elif 'right' in conf.position_tokens:        
+            x = max(conf.margin, self.img.width - maxwidth - conf.margin)
+        else:                            
+            x = max(conf.margin, (self.img.width - maxwidth) / 2) 
+        if 'top' in conf.position_tokens:            
+            y = conf.margin
+        elif 'bottom' in conf.position_tokens:       
+            y = max(conf.margin, self.img.height - maxheight - conf.margin)
+        else:                            
+            y = max(conf.margin, (self.img.height - maxheight) / 2)
+        # draw the background box with transparent color, 
+        # then composite with the original image
+        canvas = pilImage.new('RGBA', self.img.size)
+        draw = pilImageDraw.ImageDraw(canvas)
+        draw.rectangle((x - conf.padding, y - conf.padding, 
+            x + maxwidth + conf.padding, y + maxheight + conf.padding), 
+            fill=(0, 0, 0, int(255 * conf.transparency / 100.0)))
+        self.img = pilImage.alpha_composite(self.img.convert('RGBA'), canvas)
+        # draw the text
+        draw = pilImageDraw.ImageDraw(self.img)
+        for line in lines:
+            draw.text((x, y), line, font=font, 
+                fill=color if len(color) == 3 else (255,229,204))
+            y += lineheight
+        # save the image
+        self.img = self.img.convert('RGB')
+        self.img.save(os.path.join(desktop.download_directory, self.filename), 
+            "JPEG", quality=85)
+        
+        
 
 class Subreddit(object):
     def __init__(self, desktop, name, sort='top', limit=25, timeframe='month'):
@@ -666,6 +847,21 @@ def _read_config_file(desktops):
             if tokens:
                 desktop.subreddit_tokens = tokens
 
+    def parse_imprint_tokens(desktop, section):
+        for confname, funcname in ( 
+            ( 'imprint_position', 'set_position_tokens' ),
+            ( 'imprint_size',     'set_size_tokens'     ), 
+            ( 'imprint_font',     'set_font_tokens'     ),
+        ):
+            try:
+                tokens = map(lambda x: x.strip(),
+                             config.get(section, confname).split(':'))
+            except ConfigParser.NoOptionError:
+                pass
+            else:
+                if tokens:
+                    getattr(desktop.imprint_conf, funcname)(tokens)
+
     config = ConfigParser.ConfigParser()
     with open(path) as f:
         config.readfp(f)
@@ -675,6 +871,7 @@ def _read_config_file(desktops):
         if section not in config.sections():
             section = 'default'
         parse_subreddit_tokens(desktop, section)
+        parse_imprint_tokens(desktop, section)
 
     if 'default' in config.sections():
         try:
@@ -699,6 +896,10 @@ def _read_config_file(desktops):
         else:
             if image_chooser:
                 set_image_chooser(image_chooser)
+        try:
+            set_fit_images(config.getboolean('default', 'fit_images'))
+        except ConfigParser.NoOptionError:
+            pass
 
 
 def _handle_cli_options(desktops):
@@ -722,6 +923,15 @@ def _handle_cli_options(desktops):
     parser.add_argument('--what',
             action='store_true',
             help='display what images are downloaded for each desktop')
+    parser.add_argument('--imprint-position',
+            help='imprint the title in images at this position. horizontal'
+                 ' vertical (ex: bottom left)')
+    parser.add_argument('--imprint-size',
+            help='box options for title imprinting.'
+                 ' width:margin:padding:transparency')
+    parser.add_argument('--imprint-font',
+            help='font options for title imprinting.'
+                 ' filename:size:color')
     parser.add_argument('--version',
                         action='version',
                         version=__version__)
@@ -748,6 +958,12 @@ def _handle_cli_options(desktops):
     for desktop in desktops:
         if args.subreddits:
             desktop.subreddit_tokens = args.subreddits
+        if args.imprint_position:
+            desktop.imprint_conf.set_position_tokens(args.imprint_position.split(' '))
+        if args.imprint_size:
+            desktop.imprint_conf.set_size_tokens(args.imprint_size.split(':'))
+        if args.imprint_font:
+            desktop.imprint_conf.set_font_tokens(args.imprint_font.split(':'))
 
 
 def show_whats_downloaded(desktops):
@@ -788,7 +1004,6 @@ def main():
             paths = desktop.fetch_backgrounds(1)
             if paths:
                 desktop.set_background(paths[0])
-
 
 if __name__ == "__main__":
     main()

--- a/reddit-background
+++ b/reddit-background
@@ -67,7 +67,7 @@ _DOWNLOAD_DIRECTORY = None
 _IMAGE_COUNT = 0
 _OS_HANDLER = None  # Set below...
 _IMAGE_CHOOSER = None
-_FIT_IMAGES = False
+_IMAGE_SCALING = None
 
 # Consts
 WEIGHT_ASPECT_RATIO = 1.0
@@ -131,13 +131,13 @@ def get_image_chooser():
     return _IMAGE_CHOOSER or DEFAULT_IMAGE_CHOOSER
 
 
-def set_fit_images(fit_images):
-    global _FIT_IMAGES
-    _FIT_IMAGES = fit_images
+def set_image_scaling(image_scaling):
+    global _IMAGE_SCALING
+    _IMAGE_SCALING = image_scaling
 
 
-def get_fit_images():
-    return _FIT_IMAGES
+def get_image_scaling():
+    return _IMAGE_SCALING
 
 
 def _safe_makedirs(name, mode=0777):
@@ -525,7 +525,7 @@ class Desktop(object):
                 continue  # Try next image...
             else:
                 paths.append(path)
-                if get_fit_images():
+                if get_image_scaling() == 'fit':
                     image.fit_to_desktop(self)
                 if self.imprint_conf.position_tokens:
                     image.imprint_title(self)
@@ -897,7 +897,7 @@ def _read_config_file(desktops):
             if image_chooser:
                 set_image_chooser(image_chooser)
         try:
-            set_fit_images(config.getboolean('default', 'fit_images'))
+            set_image_scaling(config.get('default', 'image_scaling'))
         except ConfigParser.NoOptionError:
             pass
 


### PR DESCRIPTION
Draws the title of each image on the image pixels.  IMO, this is a more natural way to see titles and less kludgy than symlinks.  

This PR uses PIL (python imaging library), but it fails gracefully when PIL is not installed, which I hope is in keeping with the original author's goals of using only the standard library.  Modifying images like this just isn't possible without the extra library, but the program can be used with or without pillow.

This required a lot of changes to the source code, but I tried to keep with the style and structure of the original code without refactoring much.  I would suggest refactoring the use of global variables and all the set* an get* functions at the top, but that's for someone another day.  

Overall very nice project.  I hope my changes are useful to the larger audience.  If not, they do what I need.  Best wishes.  Conan